### PR TITLE
Match the behaviour of the toString method in ledge.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -354,6 +354,7 @@ export class esi {
 // Return
 // Pass in variables into ESI which identifies the request
 //
+export const esiArgsPrefix = "esi_";
 const esiArgsRegex = /^esi_(\S+)/;
 /**
  * Takes the original Request and strips ESI Args from the request
@@ -378,7 +379,7 @@ async function getVars(request: Request): Promise<[Request, ESIVars]> {
       for (const entry of current.searchParams.getAll(key)) {
         // have to append each entry seperatrely
         // trying to push an array results in sanatised arguments
-        vars.esiArgs.append(match[1], entry);
+        vars.esiArgs.append(esiArgsPrefix + match[1], entry);
       }
       current.searchParams.delete(key);
     }

--- a/src/processESIVars.ts
+++ b/src/processESIVars.ts
@@ -1,5 +1,5 @@
 import { parse } from "worktop/cookie";
-import { ESIEventData } from ".";
+import { ESIEventData, esiArgsPrefix } from ".";
 
 const esiVarsRegex = /(<esi:vars>)(.*?)(<\/esi:vars>)/gs;
 const esiVarsPatternRegex =
@@ -165,7 +165,10 @@ function _esi_eval_var(
     if (!key) {
       return esiArgs.toString();
     } else {
-      return esiArgs.has(key) ? esiArgs.getAll(key).join(", ") : default_var;
+      const keyWithPrefix = `${esiArgsPrefix}${key}`;
+      return esiArgs.has(keyWithPrefix)
+        ? esiArgs.getAll(keyWithPrefix).join(", ")
+        : default_var;
     }
   } else {
     const customVaribles = eventData.customVars;

--- a/test/esi.spec.ts
+++ b/test/esi.spec.ts
@@ -1461,7 +1461,7 @@ test("TEST 35b: ESI_ARGS works", async () => {
   const res = await makeRequest(`${url}?esi_a=test&foo=bar`);
   expect(res.ok).toBeTruthy();
   expect(checkSurrogate(res)).toBeTruthy();
-  expect(await res.text()).toEqual(`test\nnoarg\na=test\nOK`);
+  expect(await res.text()).toEqual(`test\nnoarg\nesi_a=test\nOK`);
 });
 
 test.todo("TEST 36: No error if res.has_esi incorrectly set_debug");
@@ -1770,5 +1770,21 @@ test("TEST 46b: Cookie var blacklist on fragment", async () => {
   expect(checkSurrogate(res)).toBeTruthy();
   expect(await res.text()).toEqual(
     `allowed=yes; also_allowed=yes\nyes:\nFRAGMENT:?&allowed=yes&not_allowed=\nallowed=yes; also_allowed=yes; not_allowed=no`
+  );
+});
+
+test("TEST 47: Query string", async () => {
+  const url = `/esi/test-47`;
+  routeHandler.add(`${url}?foo=Bar`, function (req, res) {
+    res.writeHead(200, esiHead);
+    res.write("<esi:vars>$(ESI_ARGS)</esi:vars>:");
+    res.write("<esi:vars>name:$(ESI_ARGS{name})</esi:vars>:");
+    res.end("<esi:vars>$(QUERY_STRING)$(QUERY_STRING{esi_name})</esi:vars>");
+  });
+  const res = await makeRequest(`${url}?esi_name=James&foo=Bar&esi_foo=Bar`);
+  expect(res.ok).toBeTruthy();
+  expect(checkSurrogate(res)).toBeTruthy();
+  expect(await res.text()).toEqual(
+    "esi_name=James&esi_foo=Bar:name:James:foo=Bar"
   );
 });


### PR DESCRIPTION
It appends the esi args prefix onto it when printing all of the ESI args

Signed-off-by: Callum Loh <callumloh@gmail.com>