### PR TITLE
Fix for bug when handling chunks that have hint tags

### DIFF
--- a/src/handleChunk.ts
+++ b/src/handleChunk.ts
@@ -28,6 +28,7 @@ export function create(writer: writerFunction): handleFunction {
 
   return async function (value: string, done: boolean): Promise<void> {
     value = prev_chunk + value;
+    prev_chunk = "";
 
     const parser = new tagParser(value);
     do {
@@ -39,7 +40,6 @@ export function create(writer: writerFunction): handleFunction {
       if (tag && tag.whole) {
         writer(tag.whole, true);
         value = after as string;
-        prev_chunk = "";
       } else if (tag && !tag.whole) {
         prev_chunk = tag.opening.tag + after;
         break;

--- a/test/handleChunk.spec.ts
+++ b/test/handleChunk.spec.ts
@@ -137,3 +137,30 @@ test("Should print our full chunk even if it's an imcomplete tag", async () => {
   await handleChunk(testString2, true);
   expect(write).toEqual(2);
 });
+
+test("Should only add hint tag on the next chunk", async () => {
+  const testString1 = "BEFORE TEXT<!--";
+  const testString2 = "help -->dfafdsafdsa";
+  const testString3 = "AFTER TEXT";
+  let write = 0;
+  const writer = function (string: string, hasESI: boolean) {
+    write++;
+    if (write == 1) {
+      expect(hasESI).toBeFalsy();
+      expect(string).toEqual("BEFORE TEXT");
+    } else if (write == 2) {
+      expect(hasESI).toBeFalsy();
+      expect(string).toEqual("<!--help -->dfafdsafdsa");
+    } else if (write == 3) {
+      expect(hasESI).toBeFalsy();
+      expect(string).toEqual("AFTER TEXT");
+    } else {
+      fail();
+    }
+  };
+  const handleChunk = createHandleChunk(writer);
+  await handleChunk(testString1, false);
+  await handleChunk(testString2, false);
+  await handleChunk(testString3, true);
+  expect(write).toEqual(3);
+});


### PR DESCRIPTION
We were not correctly cleaning up the prev_chunk between passes of chunks of data.

This caused an issue where we got a hint at a HTML tag and then on the next chunk had no ESI tags whatsoever (common on large pages).

Added unit test that covers this.