### PR TITLE
fix: handles esi Args that are strings but have leading integers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2629,13 +2629,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.3.tgz",
+      "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -12198,12 +12195,6 @@
       "engines": {
         "node": ">=14.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "tsc",
     "build-worker": "node worker/build.js",
-    "test": "npm run-script build-worker && node --experimental-vm-modules node_modules/jest/bin/jest.js --verbose --collectCoverage --coverageProvider=v8",
-    "test-debug": "npm run-script build-worker && node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js --runInBand",
+    "test": "npm run-script build-worker && node --no-experimental-fetch --experimental-vm-modules node_modules/jest/bin/jest.js --verbose --collectCoverage --coverageProvider=v8",
+    "test-debug": "npm run-script build-worker && node --no-experimental-fetch --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js --runInBand",
     "format": "prettier --write  '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
     "lint": "eslint --max-warnings=0 src && prettier --check '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
     "prepack": "npm run-script test && npm run-script lint && npm run-script build",
@@ -110,5 +110,8 @@
   },
   "dependencies": {
     "worktop": "0.7.3"
+  },
+  "overrides": {
+    "@types/node": "20.8.3"
   }
 }

--- a/src/processConditionals.ts
+++ b/src/processConditionals.ts
@@ -125,14 +125,23 @@ function esi_eval_var_in_when_tag(
   match: [String: string, ...args: string[]],
 ): string {
   const varInTag = esi_eval_var(eventData, match);
-
-  const number = parseInt(varInTag, 10);
-  if (number) {
-    return number.toString();
+  // we have to check varInTag is *actually* a number and doesn't just have leading numbers in it
+  if (strIsNumber(varInTag)) {
+    return parseInt(varInTag, 10).toString();
   } else {
     // Change to replaceAll once upgraded node
     return "'" + varInTag.replace(/'/g, "\\'") + "'";
   }
+}
+
+/**
+ * Evaluates str and returns if it *actually* is a number not just a str with leading numbers
+ *
+ * @param {string} str string to check
+ * @returns {boolean} check result
+ */
+function strIsNumber(str: string): boolean {
+  return !isNaN(Number(str));
 }
 
 /**


### PR DESCRIPTION
parseInt() returns a valid number if any of the leading characters are ints 
it drops proceeding in the string if it doesn't match