### PR TITLE
feat: pass request context to fetch function

### DIFF
--- a/test/custom-fetch.spec.ts
+++ b/test/custom-fetch.spec.ts
@@ -91,3 +91,52 @@ test("TEST 4: Custom Fetcher might want to use the POST Body", async () => {
   expect(checkSurrogate(res)).toBeTruthy();
   expect(await res.text()).toEqual("false");
 });
+
+test("TEST 5: Custom Fetcher should pass the ctx down (ie parent requets)", async () => {
+  const url = `/esi/test-5`;
+  let responseNo = 0;
+  const customFetch: fetchFunction = async function (request, init, ctx) {
+    responseNo++;
+    if (responseNo == 1)
+      return new Response(
+        `BEFORE MY CTX SHOULD JUST BE ME: ${ctx?.length} <esi:include src="${url}/fragment_1" /> AFTER`,
+        { headers: esiHead },
+      );
+    return new Response(`MY CTX SHOULD JUST BE ME AND PARENT: ${ctx?.length}`);
+  };
+  parser = new esi(config, undefined, customFetch);
+  const res = await makeRequest(url);
+  expect(res.ok).toBeTruthy();
+  expect(checkSurrogate(res)).toBeTruthy();
+  expect(await res.text()).toEqual(
+    "BEFORE MY CTX SHOULD JUST BE ME: 0 MY CTX SHOULD JUST BE ME AND PARENT: 1 AFTER",
+  );
+  expect(responseNo).toBe(2);
+});
+
+test("TEST 6: Custom Fetcher should pass the ctx down across multiple esi", async () => {
+  const url = `/esi/test-6`;
+  let responseNo = 0;
+  const customFetch: fetchFunction = async function (request, init, ctx) {
+    responseNo++;
+    if (responseNo == 1)
+      return new Response(
+        `BEFORE MY CTX SHOULD JUST BE ME: ${ctx?.length} <esi:include src="${url}/fragment_1" /> <esi:include src="${url}/fragment_2" /> <esi:include src="${url}/fragment_3" /> AFTER`,
+        { headers: esiHead },
+      );
+    if (responseNo == 3)
+      return new Response(
+        `BEFORE MY CTX SHOULD JUST BE ME AND MY PARENT: ${ctx?.length} <esi:include src="${url}/sub_fragment_1" /> AFTER`,
+        { headers: esiHead },
+      );
+    return new Response(`MY CTX SHOULD JUST BE ME AND PARENT: ${ctx?.length}`);
+  };
+  parser = new esi(config, undefined, customFetch);
+  const res = await makeRequest(url);
+  expect(res.ok).toBeTruthy();
+  expect(checkSurrogate(res)).toBeTruthy();
+  expect(await res.text()).toEqual(
+    "BEFORE MY CTX SHOULD JUST BE ME: 0 MY CTX SHOULD JUST BE ME AND PARENT: 1 BEFORE MY CTX SHOULD JUST BE ME AND MY PARENT: 1 MY CTX SHOULD JUST BE ME AND PARENT: 2 AFTER MY CTX SHOULD JUST BE ME AND PARENT: 1 AFTER",
+  );
+  expect(responseNo).toBe(5);
+});

--- a/test/postBody.spec.ts
+++ b/test/postBody.spec.ts
@@ -9,7 +9,6 @@ const esiHead = {
 };
 
 let parser: esi;
-let config: ESIConfig;
 const makeRequest = async function (request: string, details?: RequestInit) {
   const reqUrl = new URL(request, `http://localhost:${port}`).toString();
   const req = new Request(reqUrl, details);
@@ -50,7 +49,7 @@ test("TEST 1: postBody Function", async () => {
     count++;
     return;
   };
-  parser = new esi(config, undefined, undefined, postBody);
+  parser = new esi(undefined, undefined, undefined, undefined, postBody);
 
   const printFragment = function (
     req: http.IncomingMessage,
@@ -92,7 +91,7 @@ test("TEST 2: postBody Function non esi", async () => {
     count++;
     return;
   };
-  parser = new esi(config, undefined, undefined, postBody);
+  parser = new esi(undefined, undefined, undefined, undefined, postBody);
 
   routeHandler.add(url, function (req, res) {
     count++;


### PR DESCRIPTION
this allows the child request (ie esi includes) to see their parent request