### PR TITLE
fix: dont clone request when creating a mutable request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export type customESIVarsFunction = (
   request: Request,
 ) => Promise<customESIVars> | customESIVars;
 export type fetchFunction = (
-  request: RequestInfo,
+  request: Request,
   ctx: Request[],
 ) => Promise<Response>;
 export type postBodyFunction = () => void | Promise<void>;
@@ -439,7 +439,7 @@ function getVars(request: Request): [Request, ESIVars] {
   }
 
   // return a brand new
-  return [new Request(current.toString(), request.clone()), vars];
+  return [new Request(current.toString(), request), vars];
 }
 
 /**

--- a/test/esi.spec.ts
+++ b/test/esi.spec.ts
@@ -1722,7 +1722,7 @@ test("TEST 45b: Cookies and Authorization don't propagate to fragment on differe
   const url = `/esi/test-45b`;
   routeHandler.add(url, function (req, res) {
     res.writeHead(200, esiHead);
-    res.end(`<esi:include src="https://httpbin.org/get" />`);
+    res.end(`<esi:include src="https://httpbun.org/get" />`);
   });
   const res = await makeRequest(url, {
     method: "POST",


### PR DESCRIPTION
if you dont use the body of the clone workers will run out of memory with large post bodies